### PR TITLE
refactor: simplify feature flags data model

### DIFF
--- a/app/github/inject.tsx
+++ b/app/github/inject.tsx
@@ -102,7 +102,7 @@ function injectCodeIntelligence(): void {
 
 function inject(): void {
     featureFlags
-        .isEnabled('newTooltips')
+        .get('newTooltips')
         .then(isEnabled => {
             if (isEnabled) {
                 injectCodeIntelligence()

--- a/app/options.scss
+++ b/app/options.scss
@@ -100,6 +100,7 @@
     }
 
     &__input {
+        display: block;
         color: #2b3750;
         cursor: pointer;
         margin-bottom: 0;

--- a/app/util/featureFlags.ts
+++ b/app/util/featureFlags.ts
@@ -1,37 +1,29 @@
 import storage from '../../extension/storage'
-import { FeatureFlags } from '../../extension/types'
+import { Feature } from '../../extension/types'
 
 /**
  * Gets the value of a feature flag.
  * @param key is the key the feature flag is stored under.
  */
-export function get<K extends keyof FeatureFlags>(key: K): Promise<FeatureFlags[K]> {
-    return new Promise(resolve => storage.getSync(({ featureFlags }) => resolve(featureFlags[key])))
+export function get(key: Feature): Promise<boolean> {
+    return new Promise(resolve => storage.getSync(({ featureFlags }) => resolve(featureFlags && featureFlags[key])))
 }
 
 /**
  * Set the value of a feature flag.
  * @param key
  * @param val
- * @returns a promise that resolves with the new value.
+ * @returns a promise that resolves after the flag has been set.
  */
-export function set<K extends keyof FeatureFlags>(key: K, val: FeatureFlags[K]): Promise<FeatureFlags[K]> {
+export function set(key: Feature, val: boolean): Promise<void> {
     return new Promise(resolve =>
         storage.getSync(({ featureFlags }) =>
-            storage.setSync({ featureFlags: { ...featureFlags, [key]: val } }, () => get(key).then(resolve))
+            storage.setSync({ featureFlags: { ...featureFlags, [key]: val } }, resolve)
         )
     )
 }
 
-/**
- * Checks to see if the feature flag is set to a truthy value. Only useful for on/off feature flags.
- * @param key
- */
-export function isEnabled<K extends keyof FeatureFlags>(key: K): Promise<boolean> {
-    return get(key).then(val => !!val)
-}
-
 /** Toggle boolean feature flags. */
-export function toggle<K extends keyof FeatureFlags>(key: K): Promise<FeatureFlags[K]> {
+export function toggle(key: Feature): Promise<void> {
     return get(key).then(val => set(key, !val))
 }

--- a/chrome/extension/inject.tsx
+++ b/chrome/extension/inject.tsx
@@ -14,7 +14,6 @@ import {
     setRepositoryFileTreeEnabled,
     setServerUrls,
     setSourcegraphUrl,
-    setUseCXP,
 } from '../../app/util/context'
 import { getURL } from '../../extension/extension'
 import * as runtime from '../../extension/runtime'
@@ -111,7 +110,6 @@ function injectApplication(): void {
             setServerUrls(items.serverUrls)
             injectBitbucketServer()
         }
-        setUseCXP(items.useCXP === undefined ? false : items.useCXP)
     }
 
     storage.getSync(handleGetStorage)

--- a/extension/types.ts
+++ b/extension/types.ts
@@ -1,3 +1,5 @@
+import { mapValues } from 'lodash'
+
 export interface RepoLocations {
     [key: string]: string
 }
@@ -7,17 +9,36 @@ export interface PhabricatorMapping {
     path: string
 }
 
+export type Feature = 'newTooltips' | 'CXP'
+
+/**
+ * Information about a feature flag.
+ */
+export interface FeatureFlag {
+    /**
+     * This is shown next to the check box in the options UI.
+     */
+    title: string
+    default: boolean
+}
+
 /**
  * The feature flags available.
  */
-export interface FeatureFlags {
-    newTooltips: boolean
+export type FeatureFlags = Record<Feature, FeatureFlag>
+
+export const featureFlags: FeatureFlags = {
+    newTooltips: {
+        title: 'Pretty hover tooltips',
+        default: true,
+    },
+    CXP: {
+        title: 'Use new LSP client implementation',
+        default: false,
+    },
 }
 
-export const featureFlagDefaults: FeatureFlags = {
-    newTooltips: true,
-}
-
+// TODO(chris) wrap this in Partial<>
 export interface StorageItems {
     sourcegraphURL: string
     gitHubEnterpriseURL: string
@@ -39,14 +60,13 @@ export interface StorageItems {
     sourcegraphAnonymousUid: string
     disableExtension: boolean
     /**
-     * Feature flag to use new LSP funcs (standardized with sourcegraph/sourcegraph). Soon this feature flag will
-     * enable more CXP features.
-     */
-    useCXP: boolean
-    /**
      * Storage for feature flags
      */
-    featureFlags: FeatureFlags
+    featureFlags: Partial<Record<Feature, boolean>>
+    /**
+     * Overrides settings from Sourcegraph.
+     */
+    clientSettings: string
 }
 
 export const defaultStorageItems: StorageItems = {
@@ -69,8 +89,8 @@ export const defaultStorageItems: StorageItems = {
     openFileOnSourcegraph: true,
     sourcegraphAnonymousUid: '',
     disableExtension: false,
-    useCXP: false,
-    featureFlags: featureFlagDefaults,
+    featureFlags: mapValues(featureFlags, v => v.default) as Record<Feature, boolean>,
+    clientSettings: '',
 }
 
 export type StorageChange = { [key in keyof StorageItems]: chrome.storage.StorageChange }


### PR DESCRIPTION
This adds the new tooltips feature flag as a checkbox in the Experimental features section of the options popup:

![image](https://user-images.githubusercontent.com/1387653/44118846-3e3b54b8-9fcc-11e8-8515-c7f80034c660.png)

Testing plan:

- Toggle the new tooltips feature flag on/off and make sure it toggles between new and old tooltips

I have tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle
