### PR TITLE
build: fix type errors for linking dependencies

### DIFF
--- a/app/tree/Tabs.tsx
+++ b/app/tree/Tabs.tsx
@@ -69,7 +69,7 @@ interface TabsProps<T extends string> {
      */
     tabBarEndFragment?: React.ReactFragment
 
-    children: undefined | React.ReactElement<{ key: T }> | (undefined | React.ReactElement<{ key: T }>)[]
+    children: JSX.Element | undefined
 
     id?: string
     className?: string

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": "",
+    "paths": {
+      "rxjs": ["node_modules/rxjs"]
+    },
     "outDir": "./out",
     "target": "es2015",
     "module": "commonjs",


### PR DESCRIPTION
This fixes some type errors when linking dependencies (`npm link` or `yarn link`).