### PR TITLE
docs: fix broken url on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It works as follows:
 - `src/extension/`
   - Entrypoint for browser extension builds. (Includes bundled assets, background scripts, options)
 - `src/browser`
-  - [A wrapper around the browser APIs.](./browser/README.md)
+  - [A wrapper around the browser APIs.](./src/browser/README.md)
 - `src/libs/`
   - Isolated pieces of the browser extension. This contains code that is specific to code hosts and separate "mini applications" included in the browser extension such as the `src` omnibar cli.
 - `src/libs/phabricator/`


### PR DESCRIPTION
This PR changes:

The link for the browser's README.md file was broken on the main README.md.

Testing plan: N/A
I have tested on: N/A