### PR TITLE
fix(docs): remove event logging note from Firefox reviewer notes

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -55,8 +55,6 @@ publish:
       5.  Load Temporary Add-on
       6.  Click "Load Temporary Add-on" and select "build/bundles/firefox-bundle.xpi"
 
-      NOTE: This extension includes an opt-in for event tracking on GitHub.com for the purposes of personalization.
-
       How to use the extension:
       The Sourcegraph developer extension works on GitHub.com. Below you will find a list of Sourcegraph's features with relevant URLs as well as screenshots and videos to help verify the extension.
 


### PR DESCRIPTION
This PR changes:

Removes the mention of a telemetry toggle because this toggle does not exist and telemetry is not sent to Sourcegraph.com.

See: https://sourcegraph.com/github.com/sourcegraph/browser-extensions/-/blob/src/shared/tracking/EventLogger.tsx#L61:5-66:8 for implementation.

Testing plan:

<!-- provide the steps you are doing to test so others can easily know where to start -->

I have tested on:

<!--
You Don't have to test each environment before opening this PR, but provide which ones you have
tested so each can get tested by someone before this gets merged.
-->

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle
