### PR TITLE
fix: cannot create context menu item with duplicate id

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "ts-key-enum": "^2.0.0",
     "uuid": "^3.3.2",
     "vscode-languageserver-types": "3.12.0",
+    "webext-domain-permission-toggle": "^0.0.2",
     "whatwg-url": "^6.2.1"
   }
 }

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -55,7 +55,6 @@ export interface StorageItems {
      * Overrides settings from Sourcegraph.
      */
     clientSettings: string
-    hasEnableDomainContextMenu: boolean
 }
 
 interface ClientConfigurationDetails {
@@ -94,7 +93,6 @@ export const defaultStorageItems: StorageItems = {
         },
     },
     clientSettings: '',
-    hasEnableDomainContextMenu: false,
 }
 
 export type StorageChange = { [key in keyof StorageItems]: chrome.storage.StorageChange }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13648,6 +13648,11 @@ web-ext@^2.5.0:
     yargs "6.6.0"
     zip-dir "1.0.2"
 
+webext-domain-permission-toggle@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/webext-domain-permission-toggle/-/webext-domain-permission-toggle-0.0.2.tgz#28003248699b869e5422b2ef60a7c2b03e1c3c15"
+  integrity sha512-obPAEocq/5uw0jaKc1N2bwux/HXDaYz9/8ltvxTRqr0iR6JaTh6/h56FL9uoAZYXcXxjFyE+PRrJicoQrJ8T6g==
+
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
This PR resolves https://github.com/sourcegraph/browser-extensions/issues/230:

Fixes bug where "Enable Sourcegraph on this domain" context menu item would not appear.

Uses a helper lib also used in refined GitHub to add the context menu item, request permissions, display any errors to the user, show alert to refresh page after permissions are granted so the content script is injected.

Testing plan:

- Install the extension and right click on the Sourcegraph icon in the browser toolbar.
- Click "Enable Sourcegraph on this domain"
- Click "Ok" when popup appears asking "Do you want to reload this page to apply Sourcegraph"
- Notice content script is injected on the page

I have tested on:

<!--
You Don't have to test each environment before opening this PR, but provide which ones you have
tested so each can get tested by someone before this gets merged.
-->

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Phabricator Bundle
