### PR TITLE
fix: sync z-index for github tree and hover overlay

### DIFF
--- a/src/libs/code_intelligence/HoverOverlay.scss
+++ b/src/libs/code_intelligence/HoverOverlay.scss
@@ -1,4 +1,5 @@
 @import '../gitlab/style.scss';
+@import '../../global-styles/variables.scss';
 
 .hover-overlay-mount__phabricator {
     .hover-overlay {
@@ -17,4 +18,8 @@
             }
         }
     }
+}
+
+.hover-overlay {
+    z-index: $default-z-index;
 }

--- a/src/libs/gitlab/style.scss
+++ b/src/libs/gitlab/style.scss
@@ -1,7 +1,5 @@
 .hover-overlay-mount__gitlab {
     .hover-overlay {
-        z-index: 999;
-
         code {
             background: none;
             color: unset;

--- a/src/shared/global-styles/variables.scss
+++ b/src/shared/global-styles/variables.scss
@@ -1,0 +1,1 @@
+$default-z-index: 2000;

--- a/src/shared/tree/tree.scss
+++ b/src/shared/tree/tree.scss
@@ -1,8 +1,10 @@
+@import '../global-styles/variables.scss';
+
 .tree-mount {
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 2000;
+    z-index: $default-z-index;
     width: 100%;
     pointer-events: none;
     height: 100%;

--- a/src/shared/tree/tree.scss
+++ b/src/shared/tree/tree.scss
@@ -4,7 +4,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: $default-z-index;
+    z-index: $default-z-index - 1;
     width: 100%;
     pointer-events: none;
     height: 100%;


### PR DESCRIPTION
This PR changes:

Addresses an issue surfaced in https://github.com/sourcegraph/sourcegraph/issues/242 where a hover overlay gets covered up by the Github tree sidebar. This is a simple stack level bug.

Normally I would say to just update z-index for `.hover-overlay` but it would be really easy to reintroduce this bug with a simple edit to z-index on `.tree-mount`. I extracted out the value to a variables.scss file so that the z-index value be shared. I suspect that variables.scss is not a great place to put this and maybe there's an existing pattern to follow here when values need to be shared between scss files, but I couldn't find anything like that in this project.

Testing plan:

- Shrink browser window so a tooltip is likely to overflow to the left
- Hover over some symbol with information; should be easy to reproduce under the old code
- Verify that overlay now goes over GitHub tree sidebar

I have tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle
