### PR TITLE
fix: add spacing between end-of-line and decoration attachment

### DIFF
--- a/src/libs/code_intelligence/extensions.tsx
+++ b/src/libs/code_intelligence/extensions.tsx
@@ -184,7 +184,6 @@ export const applyDecoration = (
 
         const linkTo = (url: string) => (e: HTMLElement): HTMLElement => {
             const link = document.createElement('a')
-            link.className = 'sourcegraph-extension-element'
             link.setAttribute('href', url)
 
             // External URLs should open in a new tab, whereas relative URLs
@@ -200,12 +199,12 @@ export const applyDecoration = (
         }
 
         const after = document.createElement('span')
-        after.className = 'sourcegraph-extension-element'
         after.style.backgroundColor = style.backgroundColor || null
         after.textContent = decoration.after.contentText || null
         after.title = decoration.after.hoverMessage || ''
 
         const annotation = decoration.after.linkURL ? linkTo(decoration.after.linkURL)(after) : after
+        annotation.className = 'sourcegraph-extension-element line-decoration-attachment'
         codeElement.appendChild(annotation)
 
         disposables.push({

--- a/src/shared/extensions-client-common.scss
+++ b/src/shared/extensions-client-common.scss
@@ -142,3 +142,7 @@ $body-color-dark: #f2f4f8;
         }
     }
 }
+
+.line-decoration-attachment {
+    margin-left: 0.25rem;
+}


### PR DESCRIPTION
fix (in browser extension) https://github.com/sourcegraph/sourcegraph/issues/567