### PR TITLE
add back client settings for unauthed users only

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "@slimsag/react-shortcuts": "^1.2.1",
     "@sourcegraph/codeintellify": "^3.9.1",
-    "@sourcegraph/extensions-client-common": "^10.4.2",
+    "@sourcegraph/extensions-client-common": "^10.5.1",
     "@sourcegraph/react-loading-spinner": "0.0.6",
     "@sqs/jsonc-parser": "^1.0.3",
     "@types/uglifyjs-webpack-plugin": "1.1.0",

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -67,6 +67,10 @@ export interface StorageItems {
      */
     featureFlags: FeatureFlags
     clientConfiguration: ClientConfigurationDetails
+    /**
+     * Overrides settings from Sourcegraph.
+     */
+    clientSettings: string
 }
 
 interface ClientConfigurationDetails {
@@ -106,6 +110,7 @@ export const defaultStorageItems: StorageItems = {
             url: 'https://sourcegraph.com',
         },
     },
+    clientSettings: '',
 }
 
 export type StorageChange = { [key in keyof StorageItems]: chrome.storage.StorageChange }

--- a/src/libs/code_intelligence/HoverOverlay.scss
+++ b/src/libs/code_intelligence/HoverOverlay.scss
@@ -1,5 +1,5 @@
 @import '../gitlab/style.scss';
-@import '../../global-styles/variables.scss';
+@import '../../shared/global-styles/variables.scss';
 
 .hover-overlay-mount__phabricator {
     .hover-overlay {

--- a/src/shared/backend/extensions.ts
+++ b/src/shared/backend/extensions.ts
@@ -2,8 +2,18 @@ import { UpdateExtensionSettingsArgs } from '@sourcegraph/extensions-client-comm
 import { Controller as ExtensionsContextController } from '@sourcegraph/extensions-client-common/lib/controller'
 import { ConfiguredExtension } from '@sourcegraph/extensions-client-common/lib/extensions/extension'
 import { gql, graphQLContent } from '@sourcegraph/extensions-client-common/lib/graphql'
-import { ConfigurationSubject, gqlToCascade, Settings } from '@sourcegraph/extensions-client-common/lib/settings'
+import {
+    ConfigurationCascade,
+    ConfigurationCascadeOrError,
+    ConfigurationSubject,
+    gqlToCascade,
+    mergeSettings,
+    Settings,
+} from '@sourcegraph/extensions-client-common/lib/settings'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { applyEdits } from '@sqs/jsonc-parser'
+import * as JSONC from '@sqs/jsonc-parser'
+import { removeProperty, setProperty } from '@sqs/jsonc-parser/lib/edit'
 import { isEqual } from 'lodash'
 import AddIcon from 'mdi-react/AddIcon'
 import Alert from 'mdi-react/AlertIcon'
@@ -11,13 +21,13 @@ import InfoIcon from 'mdi-react/InformationIcon'
 import MenuDown from 'mdi-react/MenuDownIcon'
 import Menu from 'mdi-react/MenuIcon'
 import SettingsIcon from 'mdi-react/SettingsIcon'
-import { combineLatest, Observable, Subject, throwError } from 'rxjs'
+import { combineLatest, from, Observable, Subject, throwError } from 'rxjs'
 import { distinctUntilChanged, map, mapTo, mergeMap, startWith, switchMap, take, tap } from 'rxjs/operators'
 import { MessageTransports } from 'sourcegraph/module/protocol/jsonrpc2/connection'
 import { TextDocumentDecoration } from 'sourcegraph/module/protocol/plainTypes'
 import uuid from 'uuid'
 import { Disposable } from 'vscode-languageserver'
-import storage from '../../browser/storage'
+import storage, { StorageItems } from '../../browser/storage'
 import { GQL } from '../../types/gqlschema'
 import { ExtensionConnectionInfo, onFirstMessage } from '../messaging'
 import { canFetchForURL } from '../util/context'
@@ -128,6 +138,45 @@ export const applyDecoration = ({
     return mergeDisposables(...disposables)
 }
 
+const storageConfigurationCascade: Observable<
+    ConfigurationCascade<ConfigurationSubject, Settings>
+> = storage.observeSync('clientSettings').pipe(
+    map(clientSettingsString => JSONC.parse(clientSettingsString || '')),
+    map(clientSettings => ({
+        subjects: [
+            {
+                subject: {
+                    id: 'Client',
+                    settingsURL: 'N/A',
+                    viewerCanAdminister: true,
+                    __typename: 'Client',
+                    displayName: 'Client',
+                } as ConfigurationSubject,
+                settings: clientSettings,
+            },
+        ],
+        merged: clientSettings || {},
+    }))
+)
+
+const mergeCascades = (
+    cascadeOrError: ConfigurationCascadeOrError<ConfigurationSubject, Settings>,
+    cascade: ConfigurationCascade<ConfigurationSubject, Settings>
+): ConfigurationCascadeOrError<ConfigurationSubject, Settings> => ({
+    subjects:
+        cascadeOrError.subjects === null
+            ? cascade.subjects
+            : isErrorLike(cascadeOrError.subjects)
+                ? cascadeOrError.subjects
+                : [...cascadeOrError.subjects, ...cascade.subjects],
+    merged:
+        cascadeOrError.merged === null
+            ? cascade.merged
+            : isErrorLike(cascadeOrError.merged)
+                ? cascadeOrError.merged
+                : mergeSettings([cascadeOrError.merged, cascade.merged]),
+})
+
 const configurationCascadeFragment = gql`
     fragment ConfigurationCascadeFields on ConfigurationCascade {
         subjects {
@@ -169,7 +218,7 @@ const configurationCascadeRefreshes = new Subject<void>()
  * Always represents the entire configuration cascade; i.e., it contains the
  * individual configs from the various config subjects (orgs, user, etc.).
  */
-export const configurationCascade = combineLatest(
+export const gqlConfigurationCascade = combineLatest(
     storage.observeSync('sourcegraphURL'),
     configurationCascadeRefreshes.pipe(
         mapTo(null),
@@ -194,10 +243,40 @@ export const configurationCascade = combineLatest(
                 if (!data || !data.viewerConfiguration) {
                     throw createAggregateError(errors)
                 }
+
+                for (const subject of data.viewerConfiguration.subjects) {
+                    // User/org/global settings cannot be edited from the
+                    // browser extension (only client settings can).
+                    subject.viewerCanAdminister = false
+                }
+
                 return data.viewerConfiguration
             })
         )
     )
+)
+
+const EMPTY_CONFIGURATION_CASCADE: ConfigurationCascade = { subjects: [], merged: {} }
+
+/**
+ * The active configuration cascade.
+ *
+ * - For unauthenticated users, this is the GraphQL settings plus client settings (which are stored locally in the
+ *   browser extension.
+ * - For authenticated users, this is just the GraphQL settings (client settings are ignored to simplify the UX).
+ */
+export const configurationCascade: Observable<
+    ConfigurationCascadeOrError<ConfigurationSubject, Settings>
+> = combineLatest(gqlConfigurationCascade, storageConfigurationCascade).pipe(
+    map(([gqlCascade, storageCascade]) =>
+        mergeCascades(
+            gqlToCascade(gqlCascade),
+            gqlCascade.subjects.some(subject => subject.__typename === 'User')
+                ? EMPTY_CONFIGURATION_CASCADE
+                : storageCascade
+        )
+    ),
+    distinctUntilChanged((a, b) => isEqual(a, b))
 )
 
 export function createExtensionsContextController(
@@ -207,10 +286,7 @@ export function createExtensionsContextController(
     sourcegraphLanguageServerURL.pathname = '.api/xlang'
 
     return new ExtensionsContextController<ConfigurationSubject, Settings>({
-        configurationCascade: configurationCascade.pipe(
-            map(gqlCascade => gqlToCascade(gqlCascade)),
-            distinctUntilChanged((a, b) => isEqual(a, b))
-        ),
+        configurationCascade,
         updateExtensionSettings,
         queryGraphQL: (request, variables, requestMightContainPrivateInfo) =>
             storage.observeSync('sourcegraphURL').pipe(
@@ -250,11 +326,11 @@ export function createExtensionsContextController(
 }
 
 // TODO(sqs): copied from sourcegraph/sourcegraph temporarily
-function updateExtensionSettings(subject: string, args: UpdateExtensionSettingsArgs): Observable<void> {
-    return configurationCascade.pipe(
+function updateUserSettings(subject: string, args: UpdateExtensionSettingsArgs): Observable<void> {
+    return gqlConfigurationCascade.pipe(
         take(1),
-        switchMap(configurationCascade => {
-            const subjectConfig = configurationCascade.subjects.find(s => s.id === subject)
+        switchMap(gqlConfigurationCascade => {
+            const subjectConfig = gqlConfigurationCascade.subjects.find(s => s.id === subject)
             if (!subjectConfig) {
                 throw new Error(`no configuration subject: ${subject}`)
             }
@@ -307,4 +383,45 @@ function editConfiguration(subject: GQL.ID, lastID: number | null, edit: GQL.ICo
 // TODO(sqs): copied from sourcegraph/sourcegraph temporarily
 function toGQLKeyPath(keyPath: (string | number)[]): GQL.IKeyPathSegment[] {
     return keyPath.map(v => (typeof v === 'string' ? { property: v } : { index: v }))
+}
+
+const updateClientSettings = (subjectID: 'Client', args: UpdateExtensionSettingsArgs): Observable<void> =>
+    from(
+        new Promise<StorageItems>(resolve => storage.getSync(storageItems => resolve(storageItems))).then(
+            storageItems => {
+                let clientSettings = storageItems.clientSettings
+
+                const format = { tabSize: 2, insertSpaces: true, eol: '\n' }
+
+                if ('edit' in args && args.edit) {
+                    clientSettings = applyEdits(
+                        clientSettings,
+                        // TODO(chris): remove `.slice()` (which guards against
+                        // mutation) once
+                        // https://github.com/Microsoft/node-jsonc-parser/pull/12
+                        // is merged in.
+                        setProperty(clientSettings, args.edit.path.slice(), args.edit.value, format)
+                    )
+                } else if ('extensionID' in args) {
+                    clientSettings = applyEdits(
+                        clientSettings,
+                        typeof args.enabled === 'boolean'
+                            ? setProperty(clientSettings, ['extensions', args.extensionID], args.enabled, format)
+                            : removeProperty(clientSettings, ['extensions', args.extensionID], format)
+                    )
+                }
+                return new Promise<undefined>(resolve =>
+                    storage.setSync({ clientSettings }, () => {
+                        resolve(undefined)
+                    })
+                )
+            }
+        )
+    )
+
+export const updateExtensionSettings = (subjectID: string, args: UpdateExtensionSettingsArgs): Observable<void> => {
+    if (subjectID === 'Client') {
+        return updateClientSettings(subjectID, args)
+    }
+    return updateUserSettings(subjectID, args)
 }

--- a/src/shared/backend/headers.tsx
+++ b/src/shared/backend/headers.tsx
@@ -2,7 +2,7 @@ import { Observable, of } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
 
 import { getAccessToken } from '../auth/access_token'
-import { isContent, isInPage, isPhabricator } from '../context'
+import { isInPage, isPhabricator } from '../context'
 import { getExtensionVersionSync, getPlatformName, isSourcegraphDotCom } from '../util/context'
 
 /**
@@ -24,7 +24,7 @@ export function getHeaders(
     }
 
     return of(url).pipe(
-        switchMap(url => (isContent && useToken && !isSourcegraphDotCom(url) ? getAccessToken(url) : of(undefined))),
+        switchMap(url => (useToken && !isSourcegraphDotCom(url) ? getAccessToken(url) : of(undefined))),
         map(accessToken => {
             const headers = new Headers()
             if (accessToken) {

--- a/src/shared/backend/server.ts
+++ b/src/shared/backend/server.ts
@@ -41,6 +41,7 @@ export const fetchCurrentUser = (useAccessToken = true): Observable<GQL.IUser | 
                 username
                 avatarURL
                 url
+                settingsURL
                 emails {
                     email
                 }

--- a/src/shared/components/options/BrowserSettingsEditor.tsx
+++ b/src/shared/components/options/BrowserSettingsEditor.tsx
@@ -1,0 +1,69 @@
+// We want to polyfill first.
+import '../../../config/polyfill'
+
+import * as React from 'react'
+import { Button, FormGroup, Input, Label } from 'reactstrap'
+import { Subscription } from 'rxjs'
+import storage from '../../../browser/storage'
+
+interface State {
+    clientSettings: string
+}
+
+export class BrowserSettingsEditor extends React.Component<{}, State> {
+    private subscriptions = new Subscription()
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            clientSettings: 'Loading...',
+        }
+    }
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            storage.observeSync('clientSettings').subscribe(clientSettings => {
+                this.setState(() => ({ clientSettings }))
+            })
+        )
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    private saveLocalSettings = () => {
+        storage.setSync({ clientSettings: this.state.clientSettings })
+    }
+
+    private onSettingsChanged = event => {
+        const value = event.target.value
+        this.setState(() => ({ clientSettings: value }))
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <div>
+                <div className="options__section-contents">
+                    <FormGroup>
+                        <Label className="options__input">
+                            <Input
+                                className="options__input-textarea"
+                                type="textarea"
+                                value={this.state.clientSettings}
+                                onChange={this.onSettingsChanged}
+                                autoComplete="off"
+                                autoCorrect="off"
+                                autoCapitalize="off"
+                                spellCheck={false}
+                            />
+                        </Label>
+                        <Button className="options__cta" color="primary" onClick={this.saveLocalSettings}>
+                            Save
+                        </Button>
+                    </FormGroup>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/shared/components/options/OptionsConfiguration.tsx
+++ b/src/shared/components/options/OptionsConfiguration.tsx
@@ -7,6 +7,7 @@ import { GQL } from '../../../types/gqlschema'
 import { fetchCurrentUser } from '../../backend/server'
 import { ConnectionCard } from './ConnectionCard'
 import { FeatureFlagCard } from './FeatureFlagCard'
+import { SettingsCard } from './SettingsCard'
 
 interface Props {}
 interface State {
@@ -31,7 +32,7 @@ export class OptionsConfiguration extends React.Component<Props, State> {
     }
 
     public componentDidMount(): void {
-        fetchCurrentUser().subscribe(user => {
+        fetchCurrentUser(true).subscribe(user => {
             this.setState(() => ({ currentUser: user }))
         })
         storage.onChanged(() => {
@@ -77,6 +78,7 @@ export class OptionsConfiguration extends React.Component<Props, State> {
             <div className="options-configuration-page">
                 <ConnectionCard permissionOrigins={permissionOrigins} storage={storage} currentUser={currentUser} />
                 <FeatureFlagCard storage={storage} />
+                {storage.useExtensions && <SettingsCard currentUser={currentUser} />}
             </div>
         )
     }

--- a/src/shared/components/options/OptionsConfiguration.tsx
+++ b/src/shared/components/options/OptionsConfiguration.tsx
@@ -74,7 +74,7 @@ export class OptionsConfiguration extends React.Component<Props, State> {
             return null
         }
         return (
-            <div className="options-configuation-page">
+            <div className="options-configuration-page">
                 <ConnectionCard permissionOrigins={permissionOrigins} storage={storage} currentUser={currentUser} />
                 <FeatureFlagCard storage={storage} />
             </div>

--- a/src/shared/components/options/SettingsCard.tsx
+++ b/src/shared/components/options/SettingsCard.tsx
@@ -1,0 +1,90 @@
+import {
+    ConfigurationCascadeOrError,
+    ConfigurationSubject,
+    Settings,
+} from '@sourcegraph/extensions-client-common/lib/settings'
+import * as React from 'react'
+import { Alert, Card, CardBody, CardHeader, CardLink, CardText, Col, Row } from 'reactstrap'
+import { Subscription } from 'rxjs'
+import { GQL } from '../../../types/gqlschema'
+import { isErrorLike } from '../../backend/errors'
+import { configurationCascade } from '../../backend/extensions'
+import { sourcegraphUrl } from '../../util/context'
+import { BrowserSettingsEditor } from './BrowserSettingsEditor'
+
+interface Props {
+    currentUser: GQL.IUser | undefined
+}
+
+interface State {
+    configurationCascadeOrError?: ConfigurationCascadeOrError<ConfigurationSubject, Settings>
+}
+
+export class SettingsCard extends React.Component<Props, State> {
+    public state: State = {}
+
+    private subscriptions = new Subscription()
+
+    public componentDidMount(): void {
+        this.subscriptions.add(
+            configurationCascade.subscribe(configurationCascadeOrError =>
+                this.setState({ configurationCascadeOrError })
+            )
+        )
+    }
+
+    public componentWillUnmount(): void {
+        this.subscriptions.unsubscribe()
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <Row className="pb-3">
+                <Col>
+                    <Card>
+                        <CardHeader>Settings</CardHeader>
+                        <CardBody>
+                            {this.props.currentUser ? (
+                                <>
+                                    <CardText>
+                                        Browser extension settings are synchronized with user settings for{' '}
+                                        <strong>{this.props.currentUser.username}</strong> on{' '}
+                                        <a href={sourcegraphUrl}>{sourcegraphUrl}</a>.
+                                    </CardText>
+                                    <CardLink
+                                        className="btn btn-primary"
+                                        href={sourcegraphUrl + this.props.currentUser.settingsURL}
+                                    >
+                                        Edit user settings
+                                    </CardLink>
+                                    {this.state.configurationCascadeOrError === undefined ? (
+                                        ''
+                                    ) : isErrorLike(this.state.configurationCascadeOrError.merged) ? (
+                                        <Alert color="danger">
+                                            Error: {this.state.configurationCascadeOrError.merged.message}
+                                        </Alert>
+                                    ) : (
+                                        <>
+                                            <hr />
+                                            <pre className="card-text">
+                                                <code>
+                                                    {JSON.stringify(
+                                                        this.state.configurationCascadeOrError.merged,
+                                                        null,
+                                                        2
+                                                    )}
+                                                </code>
+                                            </pre>
+                                        </>
+                                    )}
+                                </>
+                            ) : (
+                                <BrowserSettingsEditor />
+                            )}
+                        </CardBody>
+                    </Card>
+                </Col>
+            </Row>
+        )
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,14 +1331,15 @@
     rxjs "^6.3.2"
     vscode-languageserver-types "^3.8.2"
 
-"@sourcegraph/extensions-client-common@^10.4.2":
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.4.2.tgz#f964076bf460ca1b697ebe48e9a51a5d4c3f7fa7"
-  integrity sha512-UPgOXGrDkoiOm7nPM2mdK68f1+qFEjUTAeBgDH8f5A2seMIvXVaoNAdregC7m4V/K1PTnAHort4X8j4Bpj+ZRw==
+"@sourcegraph/extensions-client-common@^10.5.1":
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/extensions-client-common/-/extensions-client-common-10.5.1.tgz#ce24e115acd90f8361656158732fcdc5f9a88df0"
+  integrity sha512-eBZ05v55aQyssEPxE24tK5MsEvuVSYq8iWd4v+vLh/dMaik9ton5OX8StH1bR9EMD8xmxDbAki+KSU6wCE646w==
   dependencies:
     "@slimsag/react-shortcuts" "^1.2.0"
     bootstrap "^4.1.3"
     lodash-es "^4.17.10"
+    marked "^0.5.1"
     react "^16.4.2"
     react-router "^4.3.1"
     react-router-dom "^4.3.1"
@@ -9755,6 +9756,11 @@ marked@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.0.tgz#9e590bad31584a48ff405b33ab1c0dd25172288e"
   integrity sha512-UhjmkCWKu1SS/BIePL2a59BMJ7V42EYtTfksodPRXzPEGEph3Inp5dylseqt+KbU9Jglsx8xcMKmlumfJMBXAA==
+
+marked@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
+  integrity sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw==
 
 math-random@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR changes:

See commit messages.

Testing plan:

1. Try extension actions that update settings as an authed user.
2. View options page as an authed user and ensure it says you are authed.
3. Delete the auto-added access token and sign out of Sourcegraph.
4. Try extension actions that update settings as an unauthed user. Confirm that the updates are reflected in the options page.
5. View options page as an unauthed user and ensure it does not say you are authed.

I have tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle