### PR TITLE
fix: code intel on diffs with newly added files

### DIFF
--- a/src/libs/github/dom_functions.ts
+++ b/src/libs/github/dom_functions.ts
@@ -202,8 +202,10 @@ export const getDiffLineRanges: CodeView['getLineRanges'] = (codeView, part) => 
         if (isCode) {
             const line = row.querySelector<HTMLElement>(
                 `td${isDomSplitDiff() ? `:nth-of-type(${part === 'base' ? 2 : 4})` : '.blob-code'}`
-            )!
+            )
+
             if (
+                !line ||
                 line.classList.contains('empty-cell') ||
                 line.classList.contains(part === 'base' ? 'blob-code-addition' : 'blob-code-deletion')
             ) {


### PR DESCRIPTION
This PR changes:

Fixes https://github.com/sourcegraph/sourcegraph/issues/605

This blue border on newly added files in diffs counted as a row, and since it doesn't have any class names, it isn't filtered out in `isCode`. Hence, we can't assume that `line` is non-null.

![image](https://user-images.githubusercontent.com/16265452/47812258-28918300-dd05-11e8-9421-fe31d3524472.png)

Testing plan:

I've tested on this PR: https://github.com/sourcegraph/sourcegraph/pull/586/files. The browser extension would break once scrolling past [licenseusercount.go](https://github.com/sourcegraph/sourcegraph/pull/586/files#diff-f9e579844875cb46d3b49926faf8c740). I confirmed this PR fixes the issue so code intel works.

I have tested on:

- [ x ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle
