### PR TITLE
refactor: use non-deprecated GraphQL Repository.name (not uri)

### DIFF
--- a/src/shared/backend/search.tsx
+++ b/src/shared/backend/search.tsx
@@ -79,7 +79,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | null 
         case 'Repository': {
             return {
                 type: 'repo',
-                title: item.uri,
+                title: item.name,
                 url: `/${item.name}`,
                 urlLabel: 'go to repository',
             }
@@ -90,7 +90,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | null 
             if (dir !== undefined && dir !== '.') {
                 descriptionParts.push(`${dir}/`)
             }
-            descriptionParts.push(basename(item.repository.uri))
+            descriptionParts.push(basename(item.repository.name))
             if (item.isDirectory) {
                 return {
                     type: 'dir',
@@ -114,7 +114,7 @@ export function createSuggestion(item: GQL.SearchSuggestion): Suggestion | null 
                 kind: item.kind,
                 title: item.name,
                 description: `${item.containerName || item.location.resource.path} — ${basename(
-                    item.location.resource.repository.uri
+                    item.location.resource.repository.name
                 )}`,
                 url: item.url,
                 urlLabel: 'go to definition',
@@ -136,7 +136,7 @@ const symbolsFragment = `
             resource {
                 path
                 repository {
-                    uri
+                    name
                 }
             }
             url
@@ -158,7 +158,7 @@ export const fetchSuggestions = (options: SearchOptions, first: number) =>
                     suggestions(first: $first) {
                         ... on Repository {
                             __typename
-                            uri
+                            name
                         }
                         ... on File {
                             __typename
@@ -167,7 +167,7 @@ export const fetchSuggestions = (options: SearchOptions, first: number) =>
                             isDirectory
                             url
                             repository {
-                                uri
+                                name
                             }
                         }
                         ... on Symbol {

--- a/src/shared/repo/backend.tsx
+++ b/src/shared/repo/backend.tsx
@@ -15,7 +15,7 @@ export const resolveParentRev = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveParentRev($repoPath: String!, $rev: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     mirrorInfo {
                         cloneInProgress
                     }
@@ -59,7 +59,7 @@ export const resolveRepo = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveRepo($repoPath: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     url
                 }
             }`,
@@ -85,7 +85,7 @@ export const resolveRev = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query ResolveRev($repoPath: String!, $rev: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     mirrorInfo {
                         cloneInProgress
                     }
@@ -180,7 +180,7 @@ export const fetchBlobContentLines = memoizeObservable(
         queryGraphQL({
             ctx: getContext({ repoKey: ctx.repoPath }),
             request: `query BlobContent($repoPath: String!, $commitID: String!, $filePath: String!) {
-                repository(uri: $repoPath) {
+                repository(name: $repoPath) {
                     commit(rev: $commitID) {
                         file(path: $filePath) {
                             content


### PR DESCRIPTION
The Repository.uri field in GraphQL (and in general) is deprecated in favor of Repository.name. This is just a different name for the same value (`name` is a better name than `uri` because the value is not actually a URI, so `uri` is a misnomer). The value that both fields contain is the string of the form `github.com/foo/bar` for a repository.

The GraphQL `Query.repository` resolver also has 2 equivalent args, `name` and `uri`, and this also changes calls to use the former (for the same reason).

There is no change in behavior.

Testing plan:

- Load a GitHub page and ensure the GraphQL queries calling `Query.repository` use the `name` arg name and succeed.

I have tested on:

<!--
You don't have to test each environment before opening this PR, but indicate which ones you have
tested so each can get tested by someone before this gets merged.
-->

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Phabricator Bundle